### PR TITLE
feat: Add automated addon update workflow

### DIFF
--- a/.github/scripts/scan-all-packages.sh
+++ b/.github/scripts/scan-all-packages.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# scan-all-packages.sh - Scan Dockerfile for all packages and check for updates
+#
+# Usage: ./scan-all-packages.sh <dockerfile> [--update]
+#
+# This script finds ALL packages with version pins in a Dockerfile and checks
+# for updates. It handles both Alpine packages (via Repology) and pinned
+# dependencies with versions.
+#
+
+set -euo pipefail
+
+DOCKERFILE="${1:-}"
+DO_UPDATE="${2:-}"
+
+if [ -z "$DOCKERFILE" ]; then
+    echo "Usage: $0 <dockerfile> [--update]"
+    exit 1
+fi
+
+if [ ! -f "$DOCKERFILE" ]; then
+    echo "Error: Dockerfile not found: $DOCKERFILE"
+    exit 1
+fi
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Cache for Repology results to avoid duplicate API calls
+declare -A REPOLOGY_CACHE
+
+# Query Repology API with caching
+query_repology_cached() {
+    local pkg="$1"
+    local repo="${2:-alpine_edge}"
+
+    local cache_key="${repo}/${pkg}"
+    if [[ -v "REPOLOGY_CACHE[$cache_key]" ]]; then
+        echo "${REPOLOGY_CACHE[$cache_key]}"
+        return
+    fi
+
+    local response
+    response=$(curl -sf "https://repology.org/api/v1/project/${pkg}" 2>/dev/null) || {
+        REPOLOGY_CACHE[$cache_key]=""
+        echo ""
+        return
+    }
+
+    local version
+    version=$(echo "$response" | jq -r --arg repo "$repo" '
+        [.[] | select(.repo == $repo)] |
+        if length > 0 then
+            (map(select(.status == "newest")) | if length > 0 then .[0].version else null end) //
+            (map(select(.status == "devel")) | if length > 0 then .[0].version else null end) //
+            .[0].version
+        else
+            null
+        end
+    ' 2>/dev/null)
+
+    if [ "$version" = "null" ]; then
+        version=""
+    fi
+
+    REPOLOGY_CACHE[$cache_key]="$version"
+    echo "$version"
+}
+
+# Extract all versioned packages from Dockerfile
+extract_packages() {
+    local packages=()
+
+    # Find packages with ==version or =version pattern (Alpine packages)
+    while IFS= read -r match; do
+        if [ -n "$match" ]; then
+            # Extract package name and version
+            if [[ "$match" =~ ([a-z0-9_-]+)==?([0-9][^[:space:]\\\"\']*) ]]; then
+                local pkg="${BASH_REMATCH[1]}"
+                local ver="${BASH_REMATCH[2]}"
+                packages+=("alpine|$pkg|$ver")
+            fi
+        fi
+    done < <(grep -oE '[a-z0-9_-]+==?[0-9][^[:space:]\\]*' "$DOCKERFILE" 2>/dev/null || true)
+
+    # Find ARG/ENV VERSION patterns (for GitHub releases, etc.)
+    while IFS= read -r line; do
+        if [[ "$line" =~ (ARG|ENV)[[:space:]]+([A-Z_]+)_VERSION=([^[:space:]]+) ]]; then
+            local var_prefix="${BASH_REMATCH[2]}"
+            local ver="${BASH_REMATCH[3]}"
+            packages+=("arg|${var_prefix}|$ver")
+        fi
+    done < "$DOCKERFILE"
+
+    printf '%s\n' "${packages[@]}"
+}
+
+# Check for renovate datasource comments
+get_datasource_for_package() {
+    local pkg="$1"
+    local datasource=""
+    local dep_name=""
+
+    # Look for renovate comment before the package
+    local in_renovate_block=false
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^#[[:space:]]*renovate:[[:space:]]*datasource=([^[:space:]]+)[[:space:]]+depName=([^[:space:]]+) ]]; then
+            datasource="${BASH_REMATCH[1]}"
+            dep_name="${BASH_REMATCH[2]}"
+            in_renovate_block=true
+        elif [ "$in_renovate_block" = true ]; then
+            if [[ "$line" =~ $pkg ]]; then
+                echo "$datasource|$dep_name"
+                return
+            elif [[ ! "$line" =~ \\ ]] && [[ ! "$line" =~ ^[[:space:]]*(RUN|ARG|ENV) ]] && [[ "$line" =~ ^[^#] ]]; then
+                in_renovate_block=false
+            fi
+        fi
+    done < "$DOCKERFILE"
+
+    echo ""
+}
+
+# Main scanning logic
+main() {
+    echo -e "${CYAN}Scanning: $DOCKERFILE${NC}"
+    echo "========================================"
+
+    local updates_available=false
+    local update_list=()
+
+    # Extract all packages
+    while IFS= read -r pkg_info; do
+        [ -z "$pkg_info" ] && continue
+
+        IFS='|' read -r type name version <<< "$pkg_info"
+
+        if [ "$type" = "alpine" ]; then
+            # Check for datasource
+            local ds_info
+            ds_info=$(get_datasource_for_package "$name")
+
+            local latest=""
+            if [ -n "$ds_info" ]; then
+                IFS='|' read -r datasource dep_name <<< "$ds_info"
+                if [ "$datasource" = "repology" ]; then
+                    local repo="${dep_name%%/*}"
+                    latest=$(query_repology_cached "$name" "$repo")
+                fi
+            else
+                # Default to alpine_edge
+                latest=$(query_repology_cached "$name" "alpine_edge")
+            fi
+
+            if [ -n "$latest" ] && [ "$latest" != "$version" ]; then
+                echo -e "${YELLOW}UPDATE:${NC} $name: $version -> $latest"
+                updates_available=true
+                update_list+=("$type|$name|$version|$latest")
+            else
+                echo -e "${GREEN}OK:${NC} $name: $version"
+            fi
+        elif [ "$type" = "arg" ]; then
+            # For ARG versions, check if there's a renovate comment
+            local ds_info
+            ds_info=$(get_datasource_for_package "VERSION=")
+
+            if [ -n "$ds_info" ]; then
+                IFS='|' read -r datasource dep_name <<< "$ds_info"
+                if [ "$datasource" = "github-releases" ]; then
+                    local latest
+                    latest=$(curl -sf "https://api.github.com/repos/${dep_name}/releases/latest" 2>/dev/null | jq -r '.tag_name // empty')
+                    if [ -n "$latest" ] && [ "$latest" != "$version" ]; then
+                        echo -e "${YELLOW}UPDATE:${NC} ${name}_VERSION: $version -> $latest"
+                        updates_available=true
+                        update_list+=("$type|${name}_VERSION|$version|$latest")
+                    else
+                        echo -e "${GREEN}OK:${NC} ${name}_VERSION: $version"
+                    fi
+                fi
+            else
+                echo -e "${GREEN}OK:${NC} ${name}_VERSION: $version (no datasource)"
+            fi
+        fi
+    done < <(extract_packages)
+
+    echo "========================================"
+
+    if [ "$updates_available" = true ]; then
+        echo -e "${YELLOW}Updates available!${NC}"
+
+        if [ "$DO_UPDATE" = "--update" ]; then
+            echo "Applying updates..."
+            for update in "${update_list[@]}"; do
+                IFS='|' read -r type name old_ver new_ver <<< "$update"
+                if [ "$type" = "alpine" ]; then
+                    sed -i "s/${name}==${old_ver}/${name}==${new_ver}/g" "$DOCKERFILE"
+                    sed -i "s/${name}=${old_ver}/${name}=${new_ver}/g" "$DOCKERFILE"
+                    echo "  Updated $name: $old_ver -> $new_ver"
+                elif [ "$type" = "arg" ]; then
+                    sed -i "s/${name}=${old_ver}/${name}=${new_ver}/g" "$DOCKERFILE"
+                    echo "  Updated $name: $old_ver -> $new_ver"
+                fi
+            done
+            echo "Updates applied."
+        fi
+    else
+        echo -e "${GREEN}All packages are up to date.${NC}"
+    fi
+}
+
+main "$@"

--- a/.github/scripts/update-addon.sh
+++ b/.github/scripts/update-addon.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+#
+# update-addon.sh - Script to check and update addon versions
+#
+# Usage: ./update-addon.sh <addon_dir> [--dry-run]
+#
+# This script:
+# 1. Parses the Dockerfile to find packages with renovate comments
+# 2. Queries APIs (Repology/GitHub) for latest versions
+# 3. Updates Dockerfile and config.yaml if updates are available
+#
+
+set -euo pipefail
+
+ADDON_DIR="${1:-}"
+DRY_RUN="${2:-false}"
+
+if [ -z "$ADDON_DIR" ]; then
+    echo "Usage: $0 <addon_dir> [--dry-run]"
+    exit 1
+fi
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+    DRY_RUN=true
+fi
+
+ADDON_NAME="${ADDON_DIR%/}"
+DOCKERFILE="${ADDON_DIR}/Dockerfile"
+CONFIG_FILE="${ADDON_DIR}/config.yaml"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Validate addon directory
+if [ ! -f "$DOCKERFILE" ]; then
+    log_error "Dockerfile not found: $DOCKERFILE"
+    exit 1
+fi
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    log_error "config.yaml not found: $CONFIG_FILE"
+    exit 1
+fi
+
+# Function to query Repology API
+query_repology() {
+    local dep_name="$1"
+    local repo="${dep_name%%/*}"
+    local pkg="${dep_name##*/}"
+
+    local response
+    response=$(curl -sf "https://repology.org/api/v1/project/${pkg}" 2>/dev/null) || {
+        log_warn "Failed to query Repology for $pkg"
+        echo ""
+        return
+    }
+
+    # Find version for the specified Alpine repository
+    local version
+    version=$(echo "$response" | jq -r --arg repo "$repo" '
+        [.[] | select(.repo == $repo)] |
+        if length > 0 then
+            (map(select(.status == "newest")) | if length > 0 then .[0].version else null end) //
+            (map(select(.status == "devel")) | if length > 0 then .[0].version else null end) //
+            .[0].version
+        else
+            null
+        end
+    ' 2>/dev/null)
+
+    if [ "$version" = "null" ] || [ -z "$version" ]; then
+        echo ""
+    else
+        echo "$version"
+    fi
+}
+
+# Function to query GitHub API for latest release
+query_github_release() {
+    local dep_name="$1"
+    local token="${GITHUB_TOKEN:-}"
+
+    local auth_header=""
+    if [ -n "$token" ]; then
+        auth_header="-H \"Authorization: token $token\""
+    fi
+
+    local response
+    response=$(curl -sf ${auth_header:+"$auth_header"} \
+        "https://api.github.com/repos/${dep_name}/releases/latest" 2>/dev/null) || {
+        log_warn "Failed to query GitHub for $dep_name"
+        echo ""
+        return
+    }
+
+    local version
+    version=$(echo "$response" | jq -r '.tag_name // empty' 2>/dev/null)
+    echo "$version"
+}
+
+# Parse Dockerfile and extract main package info
+parse_dockerfile() {
+    local datasource=""
+    local dep_name=""
+    local package_name=""
+    local current_version=""
+    local found=false
+
+    while IFS= read -r line; do
+        # Look for renovate comment
+        if [[ "$line" =~ ^#[[:space:]]*renovate:[[:space:]]*datasource=([^[:space:]]+)[[:space:]]+depName=([^[:space:]]+) ]]; then
+            datasource="${BASH_REMATCH[1]}"
+            dep_name="${BASH_REMATCH[2]}"
+            found=true
+            continue
+        fi
+
+        # If we found a renovate comment, look for the version in subsequent lines
+        if [ "$found" = true ]; then
+            if [ "$datasource" = "repology" ]; then
+                # Match package==version or package=version
+                if [[ "$line" =~ ([a-z0-9_-]+)==?([0-9][^[:space:]\\]*) ]]; then
+                    package_name="${BASH_REMATCH[1]}"
+                    current_version="${BASH_REMATCH[2]}"
+                    break
+                fi
+            elif [ "$datasource" = "github-releases" ]; then
+                # Match ARG/ENV with VERSION
+                if [[ "$line" =~ ^[[:space:]]*(ARG|ENV)[[:space:]]+[A-Z_]*VERSION=([^[:space:]]+) ]]; then
+                    current_version="${BASH_REMATCH[2]}"
+                    package_name="${dep_name##*/}"
+                    break
+                fi
+            fi
+
+            # Reset if we hit an unrelated line (not a continuation)
+            if [[ ! "$line" =~ \\ ]] && [[ ! "$line" =~ ^[[:space:]]*(RUN|ARG|ENV) ]] && [[ ! "$line" =~ ^[[:space:]]*$ ]]; then
+                found=false
+            fi
+        fi
+    done < "$DOCKERFILE"
+
+    echo "${datasource}|${dep_name}|${package_name}|${current_version}"
+}
+
+# Calculate new config version based on package version change
+calculate_config_version() {
+    local current_config_version="$1"
+    local old_package_version="$2"
+    local new_package_version="$3"
+
+    # Remove 'v' prefix if present
+    new_package_version="${new_package_version#v}"
+    old_package_version="${old_package_version#v}"
+
+    if [ "$old_package_version" != "$new_package_version" ]; then
+        # Package version changed - use new version with -1 suffix
+        echo "${new_package_version}-1"
+    else
+        # Same package version - increment suffix
+        if [[ "$current_config_version" =~ ^(.+)-([0-9]+)$ ]]; then
+            local base="${BASH_REMATCH[1]}"
+            local suffix="${BASH_REMATCH[2]}"
+            echo "${base}-$((suffix + 1))"
+        else
+            # No suffix, add -1
+            echo "${current_config_version}-1"
+        fi
+    fi
+}
+
+# Update Dockerfile with new version
+update_dockerfile() {
+    local package_name="$1"
+    local old_version="$2"
+    local new_version="$3"
+    local datasource="$4"
+
+    if [ "$datasource" = "repology" ]; then
+        # Escape special characters for sed
+        local old_escaped="${old_version//./\\.}"
+        local new_escaped="${new_version}"
+
+        # Update package==version and package=version patterns
+        sed -i "s/\(${package_name}\)==${old_escaped}/\1==${new_escaped}/g" "$DOCKERFILE"
+        sed -i "s/\(${package_name}\)=${old_escaped}/\1=${new_escaped}/g" "$DOCKERFILE"
+    elif [ "$datasource" = "github-releases" ]; then
+        sed -i "s/VERSION=${old_version}/VERSION=${new_version}/g" "$DOCKERFILE"
+    fi
+}
+
+# Update config.yaml version
+update_config() {
+    local new_version="$1"
+    yq eval -i ".version = \"${new_version}\"" "$CONFIG_FILE"
+}
+
+# Main execution
+main() {
+    log_info "Processing addon: $ADDON_NAME"
+
+    # Get current config version
+    local current_config_version
+    current_config_version=$(yq eval '.version' "$CONFIG_FILE")
+    log_info "Current config version: $current_config_version"
+
+    # Parse Dockerfile
+    local package_info
+    package_info=$(parse_dockerfile)
+    IFS='|' read -r datasource dep_name package_name current_version <<< "$package_info"
+
+    if [ -z "$datasource" ] || [ -z "$current_version" ]; then
+        log_warn "Could not detect main package info in Dockerfile"
+        exit 0
+    fi
+
+    log_info "Main package: $package_name"
+    log_info "Datasource: $datasource"
+    log_info "Current package version: $current_version"
+
+    # Query for latest version
+    local latest_version=""
+    if [ "$datasource" = "repology" ]; then
+        latest_version=$(query_repology "$dep_name")
+    elif [ "$datasource" = "github-releases" ]; then
+        latest_version=$(query_github_release "$dep_name")
+    fi
+
+    if [ -z "$latest_version" ]; then
+        log_warn "Could not fetch latest version"
+        exit 0
+    fi
+
+    log_info "Latest version available: $latest_version"
+
+    # Compare versions
+    local current_normalized="${current_version#v}"
+    local latest_normalized="${latest_version#v}"
+
+    if [ "$current_normalized" = "$latest_normalized" ]; then
+        log_info "Already up to date"
+        echo "UP_TO_DATE"
+        exit 0
+    fi
+
+    log_info "Update available: $current_version -> $latest_version"
+
+    # Calculate new config version
+    local new_config_version
+    new_config_version=$(calculate_config_version "$current_config_version" "$current_version" "$latest_version")
+    log_info "New config version: $new_config_version"
+
+    if [ "$DRY_RUN" = true ]; then
+        log_info "[DRY RUN] Would update $ADDON_NAME"
+        echo "UPDATE_AVAILABLE|$current_version|$latest_version|$new_config_version"
+        exit 0
+    fi
+
+    # Apply updates
+    log_info "Updating Dockerfile..."
+    update_dockerfile "$package_name" "$current_version" "$latest_version" "$datasource"
+
+    log_info "Updating config.yaml..."
+    update_config "$new_config_version"
+
+    log_info "Update complete"
+    echo "UPDATED|$current_version|$latest_version|$new_config_version"
+}
+
+main "$@"

--- a/.github/workflows/auto-update-addons.yaml
+++ b/.github/workflows/auto-update-addons.yaml
@@ -1,0 +1,486 @@
+name: Auto Update Addons
+
+on:
+    schedule:
+        # Run daily at 5:00 AM UTC
+        - cron: "0 5 * * *"
+    workflow_dispatch:
+        inputs:
+            addon:
+                description: "Specific addon to update (leave empty for all)"
+                required: false
+                type: string
+            dry_run:
+                description: "Dry run - only check for updates without applying"
+                required: false
+                type: boolean
+                default: false
+            update_all_packages:
+                description: "Update all packages in Dockerfiles (not just main package)"
+                required: false
+                type: boolean
+                default: true
+
+env:
+    GIT_AUTHOR_NAME: "github-actions[bot]"
+    GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+    GIT_COMMITTER_NAME: "github-actions[bot]"
+    GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+
+jobs:
+    scan-and-update:
+        name: Scan and Update Addons
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Install dependencies
+              run: |
+                  sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+                  sudo chmod +x /usr/local/bin/yq
+
+            - name: Scan and update addons
+              id: update
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  DRY_RUN: ${{ inputs.dry_run || 'false' }}
+                  TARGET_ADDON: ${{ inputs.addon || '' }}
+                  UPDATE_ALL_PACKAGES: ${{ inputs.update_all_packages || 'true' }}
+              run: |
+                  set -euo pipefail
+
+                  UPDATES_FOUND=false
+                  UPDATED_ADDONS=""
+                  UPDATE_SUMMARY=""
+
+                  # Cache for Repology API results
+                  declare -A REPOLOGY_CACHE
+
+                  # Function to query Repology API for Alpine package version (with caching)
+                  get_repology_version() {
+                      local dep_name="$1"
+                      # dep_name format: alpine_edge/package-name or just package-name
+                      local repo pkg
+
+                      if [[ "$dep_name" == */* ]]; then
+                          repo="${dep_name%%/*}"
+                          pkg="${dep_name##*/}"
+                      else
+                          repo="alpine_edge"
+                          pkg="$dep_name"
+                      fi
+
+                      # Check cache
+                      local cache_key="${repo}/${pkg}"
+                      if [[ -v "REPOLOGY_CACHE[$cache_key]" ]]; then
+                          echo "${REPOLOGY_CACHE[$cache_key]}"
+                          return
+                      fi
+
+                      # Query repology API
+                      local response
+                      response=$(curl -sf "https://repology.org/api/v1/project/${pkg}" 2>/dev/null || echo "[]")
+
+                      # Find the version for the specified Alpine repository
+                      local version
+                      version=$(echo "$response" | jq -r --arg repo "$repo" '
+                          [.[] | select(.repo == $repo)] |
+                          if length > 0 then
+                              (map(select(.status == "newest")) | if length > 0 then .[0].version else null end) //
+                              (map(select(.status == "devel")) | if length > 0 then .[0].version else null end) //
+                              .[0].version
+                          else
+                              null
+                          end
+                      ' 2>/dev/null)
+
+                      if [ -z "$version" ] || [ "$version" = "null" ]; then
+                          version=""
+                      fi
+
+                      REPOLOGY_CACHE[$cache_key]="$version"
+                      echo "$version"
+                  }
+
+                  # Function to query GitHub API for latest release
+                  get_github_release_version() {
+                      local dep_name="$1"
+                      local response
+                      response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+                          "https://api.github.com/repos/${dep_name}/releases/latest" 2>/dev/null || echo "{}")
+
+                      local version
+                      version=$(echo "$response" | jq -r '.tag_name // empty' 2>/dev/null)
+                      echo "$version"
+                  }
+
+                  # Function to extract main package info from Dockerfile
+                  get_main_package_info() {
+                      local dockerfile="$1"
+                      local datasource=""
+                      local dep_name=""
+                      local current_version=""
+                      local package_name=""
+
+                      # Look for renovate comment to identify main package
+                      while IFS= read -r line; do
+                          if [[ "$line" =~ ^#[[:space:]]*renovate:[[:space:]]*datasource=([^[:space:]]+)[[:space:]]+depName=([^[:space:]]+) ]]; then
+                              datasource="${BASH_REMATCH[1]}"
+                              dep_name="${BASH_REMATCH[2]}"
+
+                              # Read next lines to find version
+                              if [ "$datasource" = "repology" ]; then
+                                  # For repology, look for package==version or package=version pattern
+                                  # Read until we find the package version
+                                  local in_block=true
+                                  while IFS= read -r next_line && [ "$in_block" = true ]; do
+                                      # Match package==version or package=version
+                                      if [[ "$next_line" =~ ([a-z0-9_-]+)==?([0-9][^[:space:]\\]*) ]]; then
+                                          package_name="${BASH_REMATCH[1]}"
+                                          current_version="${BASH_REMATCH[2]}"
+                                          break 2
+                                      fi
+                                      # Stop if we hit another comment or empty line outside continuation
+                                      if [[ ! "$next_line" =~ \\ ]] && [[ ! "$next_line" =~ ^[[:space:]]*[a-z] ]]; then
+                                          break
+                                      fi
+                                  done
+                              elif [ "$datasource" = "github-releases" ]; then
+                                  # For github-releases, look for ARG/ENV with VERSION
+                                  while IFS= read -r next_line; do
+                                      if [[ "$next_line" =~ (ARG|ENV)[[:space:]]+[A-Z_]*VERSION=([^[:space:]]+) ]]; then
+                                          current_version="${BASH_REMATCH[2]}"
+                                          package_name="${dep_name##*/}"
+                                          break 2
+                                      fi
+                                      if [[ "$next_line" =~ ^# ]] || [[ -z "$next_line" ]]; then
+                                          continue
+                                      fi
+                                      if [[ ! "$next_line" =~ ^(ARG|ENV) ]]; then
+                                          break
+                                      fi
+                                  done
+                              fi
+                          fi
+                      done < "$dockerfile"
+
+                      echo "${datasource}|${dep_name}|${package_name}|${current_version}"
+                  }
+
+                  # Function to update version in Dockerfile
+                  update_dockerfile_version() {
+                      local dockerfile="$1"
+                      local package_name="$2"
+                      local old_version="$3"
+                      local new_version="$4"
+                      local datasource="$5"
+
+                      if [ "$datasource" = "repology" ]; then
+                          # Update package==version or package=version
+                          sed -i "s/${package_name}==${old_version}/${package_name}==${new_version}/g" "$dockerfile"
+                          sed -i "s/${package_name}=${old_version}/${package_name}=${new_version}/g" "$dockerfile"
+                      elif [ "$datasource" = "github-releases" ]; then
+                          # Update ARG/ENV VERSION
+                          sed -i "s/VERSION=${old_version}/VERSION=${new_version}/g" "$dockerfile"
+                      fi
+                  }
+
+                  # Function to calculate new config version
+                  calculate_config_version() {
+                      local current_config_version="$1"
+                      local old_package_version="$2"
+                      local new_package_version="$3"
+
+                      # Remove 'v' prefix if present (for github releases)
+                      new_package_version="${new_package_version#v}"
+                      old_package_version="${old_package_version#v}"
+
+                      # Check if package version changed
+                      if [ "$old_package_version" != "$new_package_version" ]; then
+                          # New package version - reset suffix to -1
+                          echo "${new_package_version}-1"
+                      else
+                          # Same package version - increment suffix
+                          if [[ "$current_config_version" =~ ^(.+)-([0-9]+)$ ]]; then
+                              local base="${BASH_REMATCH[1]}"
+                              local suffix="${BASH_REMATCH[2]}"
+                              echo "${base}-$((suffix + 1))"
+                          else
+                              # No suffix exists, add -1
+                              echo "${current_config_version}-1"
+                          fi
+                      fi
+                  }
+
+                  # Function to update config.yaml version
+                  update_config_version() {
+                      local config_file="$1"
+                      local new_version="$2"
+
+                      yq eval -i ".version = \"${new_version}\"" "$config_file"
+                  }
+
+                  # Function to update all packages in a Dockerfile
+                  update_all_dockerfile_packages() {
+                      local dockerfile="$1"
+                      local addon_name="$2"
+                      local packages_updated=""
+
+                      echo "  Scanning all packages in Dockerfile..."
+
+                      # Find all packages with ==version or =version pattern
+                      while IFS= read -r match; do
+                          if [[ "$match" =~ ([a-z0-9_-]+)==?([0-9][^[:space:]\\]*) ]]; then
+                              local pkg="${BASH_REMATCH[1]}"
+                              local current_ver="${BASH_REMATCH[2]}"
+
+                              # Get latest version from Repology
+                              local latest_ver
+                              latest_ver=$(get_repology_version "$pkg")
+
+                              if [ -n "$latest_ver" ] && [ "$latest_ver" != "$current_ver" ]; then
+                                  echo "    Package $pkg: $current_ver -> $latest_ver"
+
+                                  if [ "$DRY_RUN" != "true" ]; then
+                                      # Update both == and = patterns
+                                      sed -i "s/${pkg}==${current_ver}/${pkg}==${latest_ver}/g" "$dockerfile"
+                                      sed -i "s/${pkg}=${current_ver}/${pkg}=${latest_ver}/g" "$dockerfile"
+                                  fi
+
+                                  packages_updated="${packages_updated}${pkg}:${current_ver}->${latest_ver},"
+                              fi
+                          fi
+                      done < <(grep -oE '[a-z0-9_-]+==?[0-9][^[:space:]\\]*' "$dockerfile" 2>/dev/null || true)
+
+                      echo "$packages_updated"
+                  }
+
+                  # Main logic: iterate through all addon directories
+                  echo "Scanning addon directories..."
+
+                  for addon_dir in */; do
+                      addon_name="${addon_dir%/}"
+
+                      # Skip if not an addon directory (no Dockerfile)
+                      if [ ! -f "${addon_dir}Dockerfile" ]; then
+                          continue
+                      fi
+
+                      # Skip if specific addon requested and this isn't it
+                      if [ -n "$TARGET_ADDON" ] && [ "$addon_name" != "$TARGET_ADDON" ]; then
+                          continue
+                      fi
+
+                      echo "----------------------------------------"
+                      echo "Processing addon: $addon_name"
+
+                      dockerfile="${addon_dir}Dockerfile"
+                      config_file="${addon_dir}config.yaml"
+
+                      if [ ! -f "$config_file" ]; then
+                          echo "  Warning: config.yaml not found, skipping"
+                          continue
+                      fi
+
+                      # Get current config version
+                      current_config_version=$(yq eval '.version' "$config_file")
+                      echo "  Current config version: $current_config_version"
+
+                      # Get main package info from Dockerfile
+                      package_info=$(get_main_package_info "$dockerfile")
+                      IFS='|' read -r datasource dep_name package_name current_version <<< "$package_info"
+
+                      if [ -z "$datasource" ] || [ -z "$current_version" ]; then
+                          echo "  Warning: Could not detect main package info, skipping"
+                          continue
+                      fi
+
+                      echo "  Main package: $package_name"
+                      echo "  Datasource: $datasource"
+                      echo "  Current package version: $current_version"
+                      echo "  Dependency name: $dep_name"
+
+                      # Get latest version
+                      latest_version=""
+                      if [ "$datasource" = "repology" ]; then
+                          latest_version=$(get_repology_version "$dep_name")
+                      elif [ "$datasource" = "github-releases" ]; then
+                          latest_version=$(get_github_release_version "$dep_name")
+                      fi
+
+                      if [ -z "$latest_version" ]; then
+                          echo "  Warning: Could not fetch latest version, skipping"
+                          continue
+                      fi
+
+                      echo "  Latest version available: $latest_version"
+
+                      # Compare versions (normalize github versions by removing 'v' prefix)
+                      current_normalized="${current_version#v}"
+                      latest_normalized="${latest_version#v}"
+
+                      if [ "$current_normalized" = "$latest_normalized" ]; then
+                          echo "  Main package already up to date"
+
+                          # Still check for other package updates if enabled
+                          if [ "$UPDATE_ALL_PACKAGES" = "true" ]; then
+                              local other_packages_updated
+                              other_packages_updated=$(update_all_dockerfile_packages "$dockerfile" "$addon_name")
+
+                              if [ -n "$other_packages_updated" ]; then
+                                  echo "  Other packages need updating: $other_packages_updated"
+
+                                  if [ "$DRY_RUN" != "true" ]; then
+                                      # Increment config version suffix for other package updates
+                                      local incremented_version
+                                      if [[ "$current_config_version" =~ ^(.+)-([0-9]+)$ ]]; then
+                                          local base="${BASH_REMATCH[1]}"
+                                          local suffix="${BASH_REMATCH[2]}"
+                                          incremented_version="${base}-$((suffix + 1))"
+                                      else
+                                          incremented_version="${current_config_version}-1"
+                                      fi
+
+                                      update_config_version "$config_file" "$incremented_version"
+
+                                      UPDATES_FOUND=true
+                                      UPDATED_ADDONS="${UPDATED_ADDONS}${addon_name},"
+                                      UPDATE_SUMMARY="${UPDATE_SUMMARY}- **${addon_name}**: dependency updates (config: ${incremented_version})\n  - Packages: ${other_packages_updated%,}\n"
+                                  else
+                                      UPDATES_FOUND=true
+                                      UPDATE_SUMMARY="${UPDATE_SUMMARY}- **${addon_name}**: dependency updates available\n  - Packages: ${other_packages_updated%,}\n"
+                                  fi
+                              fi
+                          fi
+
+                          continue
+                      fi
+
+                      echo "  Update available: $current_version -> $latest_version"
+
+                      # Calculate new config version
+                      new_config_version=$(calculate_config_version "$current_config_version" "$current_version" "$latest_version")
+                      echo "  New config version will be: $new_config_version"
+
+                      if [ "$DRY_RUN" = "true" ]; then
+                          echo "  [DRY RUN] Would update $addon_name"
+
+                          # Also check other packages in dry run mode
+                          local other_packages=""
+                          if [ "$UPDATE_ALL_PACKAGES" = "true" ]; then
+                              other_packages=$(update_all_dockerfile_packages "$dockerfile" "$addon_name")
+                          fi
+
+                          UPDATES_FOUND=true
+                          local summary_line="- **${addon_name}**: ${package_name} ${current_version} -> ${latest_version} (config: ${new_config_version})"
+                          if [ -n "$other_packages" ]; then
+                              summary_line="${summary_line}\n  - Other packages to update: ${other_packages%,}"
+                          fi
+                          UPDATE_SUMMARY="${UPDATE_SUMMARY}${summary_line}\n"
+                          continue
+                      fi
+
+                      # Apply updates
+                      echo "  Updating main package in Dockerfile..."
+                      update_dockerfile_version "$dockerfile" "$package_name" "$current_version" "$latest_version" "$datasource"
+
+                      # Update all other packages if enabled
+                      local other_packages_updated=""
+                      if [ "$UPDATE_ALL_PACKAGES" = "true" ]; then
+                          other_packages_updated=$(update_all_dockerfile_packages "$dockerfile" "$addon_name")
+                      fi
+
+                      echo "  Updating config.yaml..."
+                      update_config_version "$config_file" "$new_config_version"
+
+                      UPDATES_FOUND=true
+                      UPDATED_ADDONS="${UPDATED_ADDONS}${addon_name},"
+
+                      local summary_line="- **${addon_name}**: ${package_name} ${current_version} -> ${latest_version} (config: ${new_config_version})"
+                      if [ -n "$other_packages_updated" ]; then
+                          summary_line="${summary_line}\n  - Other packages updated: ${other_packages_updated%,}"
+                      fi
+                      UPDATE_SUMMARY="${UPDATE_SUMMARY}${summary_line}\n"
+
+                      echo "  Done updating $addon_name"
+                  done
+
+                  echo "----------------------------------------"
+                  echo "Scan complete"
+
+                  # Set outputs
+                  echo "updates_found=$UPDATES_FOUND" >> $GITHUB_OUTPUT
+                  echo "updated_addons=${UPDATED_ADDONS%,}" >> $GITHUB_OUTPUT
+
+                  # Store summary for PR body
+                  {
+                      echo "update_summary<<EOF"
+                      echo -e "$UPDATE_SUMMARY"
+                      echo "EOF"
+                  } >> $GITHUB_OUTPUT
+
+            - name: Check for changes
+              id: changes
+              if: steps.update.outputs.updates_found == 'true' && inputs.dry_run != true
+              run: |
+                  if git diff --quiet; then
+                      echo "has_changes=false" >> $GITHUB_OUTPUT
+                  else
+                      echo "has_changes=true" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Create Pull Request
+              if: steps.changes.outputs.has_changes == 'true'
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  commit-message: "chore: auto-update addon versions"
+                  title: "chore: Auto-update addon versions"
+                  body: |
+                      ## Automated Addon Updates
+
+                      This PR was automatically generated by the addon auto-update workflow.
+
+                      ### Updates
+
+                      ${{ steps.update.outputs.update_summary }}
+
+                      ### Checklist
+
+                      - [ ] Review the version changes
+                      - [ ] Verify the addons build correctly
+                      - [ ] Test the updated addons if possible
+                  branch: auto-update/addon-versions
+                  delete-branch: true
+                  labels: |
+                      dependencies
+                      automated
+
+            - name: Summary
+              if: always()
+              run: |
+                  echo "## Addon Update Summary" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+
+                  if [ "${{ inputs.dry_run }}" = "true" ]; then
+                      echo "**Mode:** Dry Run (no changes applied)" >> $GITHUB_STEP_SUMMARY
+                  else
+                      echo "**Mode:** Live Update" >> $GITHUB_STEP_SUMMARY
+                  fi
+
+                  echo "" >> $GITHUB_STEP_SUMMARY
+
+                  if [ "${{ steps.update.outputs.updates_found }}" = "true" ]; then
+                      echo "### Updates Found" >> $GITHUB_STEP_SUMMARY
+                      echo "" >> $GITHUB_STEP_SUMMARY
+                      echo -e "${{ steps.update.outputs.update_summary }}" >> $GITHUB_STEP_SUMMARY
+                  else
+                      echo "No updates found. All addons are up to date." >> $GITHUB_STEP_SUMMARY
+                  fi


### PR DESCRIPTION
Add a GitHub Actions workflow that automatically scans all Dockerfiles
for package updates and updates both the Dockerfiles and config.yaml
version keys accordingly.

Features:
- Runs on schedule (daily at 5:00 AM UTC) and on-demand
- Scans all addon directories for Dockerfiles
- Queries Repology API for Alpine package updates
- Queries GitHub API for release-based dependencies
- Updates all packages in Dockerfiles (configurable)
- Updates config.yaml version with main package version + iterative suffix
- Creates a PR with detailed summary of all changes
- Supports dry-run mode for previewing changes
- Can target specific addons

Version scheme: main_package_version-N where N increments for
non-main-package updates and resets to 1 when main package updates.